### PR TITLE
Implement Chain<T>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+data/*
+src/main.rs

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -163,7 +163,6 @@ where
             state.remove(0);
             state.push(next_word);
         }
-        println!("Generated state: {:?}", result);
         result
     }
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -15,9 +15,9 @@ pub struct Chain<T>
 where
     T: Eq + Hash + Clone + std::fmt::Debug,
 {
-    model: Model<T>,
     token_begin: T,
     token_end: T,
+    model: Model<T>,
     begin_choices: Vec<T>,
     begin_weights: Vec<i32>,
 }
@@ -29,9 +29,9 @@ where
     /// Creates an empty Chain.
     pub fn default(begin: T, end: T) -> Self {
         Self {
-            model: HashMap::new(),
             token_begin: begin,
             token_end: end,
+            model: Model::new(),
             begin_choices: Vec::new(),
             begin_weights: Vec::new(),
         }
@@ -70,7 +70,6 @@ where
     T: Eq + Hash + Clone + std::fmt::Debug,
 {
     /// Creates a new Chain from the given data.
-    ///
     /// # Arguments
     /// * `data` - A reference to a slice of vectors of strings, where each vector represents a sequence of words.
     /// # Returns
@@ -123,7 +122,6 @@ where
     }
 
     /// Moves to the next state based on the current state.
-    ///
     /// # Arguments
     /// * `state` - A reference to the current state of the Markov chain.
     /// # Returns

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,25 +1,42 @@
 use std::collections::HashMap;
+use std::hash::Hash;
 
 use rand::Rng;
 
-const BEGIN: &str = "___BEGIN__";
-const END: &str = "___END__";
-
 const STATE_SIZE: usize = 2;
 
-type State = Vec<String>;
-type Weight = HashMap<String, i32>;
-type Model = HashMap<State, Weight>;
+type State<T> = Vec<T>;
+type Weight<T> = HashMap<T, i32>;
+type Model<T> = HashMap<State<T>, Weight<T>>;
 
 /// Chain is used internally to generate text based on a Markov model.
-#[derive(Debug, Default)]
-pub struct Chain {
-    model: Model,
-    begin_choices: Vec<String>,
+#[derive(Debug)]
+pub struct Chain<T>
+where
+    T: Eq + Hash + Clone,
+{
+    model: Model<T>,
+    token_begin: T,
+    token_end: T,
+    begin_choices: Vec<T>,
     begin_weights: Vec<i32>,
 }
 
-impl Chain {
+impl<T> Chain<T>
+where
+    T: Eq + Hash + Clone,
+{
+    /// Creates an empty Chain.
+    pub fn default(begin: T, end: T) -> Self {
+        Self {
+            model: HashMap::new(),
+            token_begin: begin,
+            token_end: end,
+            begin_choices: Vec::new(),
+            begin_weights: Vec::new(),
+        }
+    }
+
     /// Accumulate a list of integers into a cumulative distribution.
     fn accumulate(ns: &[i32]) -> Vec<i32> {
         let mut numbers: Vec<i32> = Vec::with_capacity(ns.len());
@@ -32,15 +49,15 @@ impl Chain {
     }
 
     /// Compile the next possible words and their cumulative weights.
-    fn compile_next(data: &Weight) -> (Vec<String>, Vec<i32>) {
-        let words: Vec<String> = data.keys().cloned().collect();
+    fn compile_next(data: &Weight<T>) -> (Vec<T>, Vec<i32>) {
+        let words: Vec<T> = data.keys().cloned().collect();
         let weights: Vec<i32> = data.values().cloned().collect();
         let cum: Vec<i32> = Self::accumulate(&weights);
         (words, cum)
     }
 
     /// Refer to python's `bisect.bisect`, this is more or less the same.
-    fn bisect_right<T: Ord>(slice: &[T], x: &T) -> usize {
+    fn bisect_right<X: Ord>(slice: &[X], x: &X) -> usize {
         match slice.binary_search(x) {
             Ok(idx) => idx + 1,
             Err(idx) => idx,
@@ -48,40 +65,40 @@ impl Chain {
     }
 }
 
-impl Chain {
+impl<T> Chain<T>
+where
+    T: Eq + Hash + Clone,
+{
     /// Creates a new Chain from the given data.
     ///
     /// # Arguments
     /// * `data` - A reference to a slice of vectors of strings, where each vector represents a sequence of words.
     /// # Returns
     /// A new instance of `Chain`.
-    pub fn new(data: &[Vec<String>]) -> Self {
-        let mut chain = Self::default();
+    pub fn new(data: &[Vec<T>], begin: T, end: T) -> Self {
+        let mut chain = Self::default(begin, end);
         chain.model = chain.build(data);
         chain.compute();
         chain
     }
 
     /// Builds the Markov model from the provided data.
-    fn build(&self, data: &[Vec<String>]) -> Model {
-        let mut model: Model = HashMap::new();
+    fn build(&self, data: &[Vec<T>]) -> Model<T> {
+        let mut model: Model<T> = HashMap::new();
 
         for run in data {
-            let mut items: Vec<&str> = vec![BEGIN; STATE_SIZE];
-            items.extend(run.iter().map(|s| s.as_str()));
-            items.push(END);
+            let mut items: Vec<&T> = vec![&self.token_begin; STATE_SIZE];
+            items.extend(run);
+            items.push(&self.token_end);
 
             for i in 0..run.len() + 1 {
-                let state: State = items[i..i + STATE_SIZE]
-                    .iter()
-                    .map(|s| (*s).to_string())
-                    .collect::<Vec<String>>();
-                let follow: &str = items[i + STATE_SIZE];
+                let state: State<T> = items[i..i + STATE_SIZE].iter().cloned().cloned().collect();
+                let follow: &T = items[i + STATE_SIZE];
 
                 model
                     .entry(state)
                     .or_insert_with(HashMap::new)
-                    .entry(follow.to_string())
+                    .entry(follow.clone())
                     .and_modify(|e| *e += 1)
                     .or_insert(1);
             }
@@ -91,8 +108,8 @@ impl Chain {
     }
 
     /// Returns the initial state of the Markov chain.
-    fn begin_state(&self) -> State {
-        vec![BEGIN.to_string(); STATE_SIZE]
+    fn begin_state(&self) -> State<T> {
+        vec![self.token_begin.clone(); STATE_SIZE]
     }
 
     /// Precomputes the choices and weights for the initial state.
@@ -110,8 +127,8 @@ impl Chain {
     /// # Arguments
     /// * `state` - A reference to the current state of the Markov chain.
     /// # Returns
-    /// A string representing the next word in the sequence.
-    pub fn next(&self, state: &State) -> String {
+    /// A <T> representing the next token in the sequence.
+    pub fn next(&self, state: &State<T>) -> T {
         let (mut choices, mut cumdist) = (self.begin_choices.clone(), self.begin_weights.clone());
         if state != &self.begin_state() {
             // FIXME: This is bad
@@ -134,12 +151,12 @@ impl Chain {
     /// * `init_state` - An optional initial state to start the generation from.
     /// # Returns
     /// A vector of strings representing the generated sequence of words.
-    pub fn generate(&self, init_state: Option<State>) -> Vec<String> {
+    pub fn generate(&self, init_state: Option<State<T>>) -> Vec<T> {
         let mut state = init_state.unwrap_or(self.begin_state());
-        let mut result: Vec<String> = Vec::new();
+        let mut result: Vec<T> = Vec::new();
         loop {
-            let next_word: String = self.next(&state);
-            if next_word == END {
+            let next_word: T = self.next(&state);
+            if next_word == self.token_end {
                 break;
             }
             result.push(next_word.clone());

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -13,7 +13,7 @@ type Model<T> = HashMap<State<T>, Weight<T>>;
 #[derive(Debug)]
 pub struct Chain<T>
 where
-    T: Eq + Hash + Clone,
+    T: Eq + Hash + Clone + std::fmt::Debug,
 {
     model: Model<T>,
     token_begin: T,
@@ -24,7 +24,7 @@ where
 
 impl<T> Chain<T>
 where
-    T: Eq + Hash + Clone,
+    T: Eq + Hash + Clone + std::fmt::Debug,
 {
     /// Creates an empty Chain.
     pub fn default(begin: T, end: T) -> Self {
@@ -67,7 +67,7 @@ where
 
 impl<T> Chain<T>
 where
-    T: Eq + Hash + Clone,
+    T: Eq + Hash + Clone + std::fmt::Debug,
 {
     /// Creates a new Chain from the given data.
     ///
@@ -163,6 +163,7 @@ where
             state.remove(0);
             state.push(next_word);
         }
+        println!("Generated state: {:?}", result);
         result
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod chain;
 pub mod text;
+pub mod vocab;
 
 pub use chain::Chain;
 pub use text::{Text, TextOptions};
+pub use vocab::Vocab;

--- a/src/text.rs
+++ b/src/text.rs
@@ -4,6 +4,9 @@ use regex::Regex;
 const MOR: f32 = 0.7; // max overlap ratio
 const MOT: usize = 15; // max overlap total
 
+const BEGIN: &str = "___BEGIN__";
+const END: &str = "___END__";
+
 /// Options for generating text.
 #[derive(Debug)]
 pub struct TextOptions {
@@ -23,15 +26,25 @@ impl Default for TextOptions {
 }
 
 /// Text is the main structure for generating text based on a Markov model.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Text {
     reject: Option<Regex>,
     parsed_sentences: Vec<Vec<String>>,
     rejoined_text: String,
-    chain: Chain,
+    chain: Chain<String>,
 }
 
 impl Text {
+    /// Creates a default Text instance.
+    fn default() -> Self {
+        Self {
+            reject: None,
+            parsed_sentences: Vec::new(),
+            rejoined_text: String::new(),
+            chain: Chain::default(BEGIN.to_string(), END.to_string()),
+        }
+    }
+
     /// Validates the input sentence.
     fn sentence_input(&self, s: &str) -> bool {
         if s.trim().is_empty() {
@@ -91,7 +104,7 @@ impl Text {
             .map(|s| s.join(" "))
             .collect::<Vec<String>>()
             .join(" ");
-        text.chain = Chain::new(&text.parsed_sentences);
+        text.chain = Chain::new(&text.parsed_sentences, BEGIN.to_string(), END.to_string());
 
         text
     }

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Vocab {
-    pub word_to_id: HashMap<String, u32>,
-    pub id_to_word: Vec<String>,
+    word_to_id: HashMap<String, u32>,
+    id_to_word: Vec<String>,
 }
 
 impl Vocab {
@@ -14,14 +14,23 @@ impl Vocab {
         }
     }
 
-    pub fn get_or_insert(&mut self, word: &str) -> u32 {
+    pub fn to_token(&mut self, word: &str) -> u32 {
         if let Some(&id) = self.word_to_id.get(word) {
-            id
-        } else {
-            let id = self.id_to_word.len() as u32;
-            self.word_to_id.insert(word.to_string(), id);
-            self.id_to_word.push(word.to_string());
-            id
+            return id;
         }
+
+        let id = self.id_to_word.len() as u32;
+        self.id_to_word.push(word.to_owned());
+        let inserted = self.id_to_word.last().unwrap().clone();
+        self.word_to_id.insert(inserted, id);
+
+        id
+    }
+
+    pub fn to_word(&self, token: u32) -> &str {
+        self.id_to_word
+            .get(token as usize)
+            .map(|s| s.as_str())
+            .unwrap_or("")
     }
 }

--- a/src/vocab.rs
+++ b/src/vocab.rs
@@ -1,0 +1,27 @@
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Vocab {
+    pub word_to_id: HashMap<String, u32>,
+    pub id_to_word: Vec<String>,
+}
+
+impl Vocab {
+    pub fn new() -> Self {
+        Self {
+            word_to_id: HashMap::new(),
+            id_to_word: Vec::new(),
+        }
+    }
+
+    pub fn get_or_insert(&mut self, word: &str) -> u32 {
+        if let Some(&id) = self.word_to_id.get(word) {
+            id
+        } else {
+            let id = self.id_to_word.len() as u32;
+            self.word_to_id.insert(word.to_string(), id);
+            self.id_to_word.push(word.to_string());
+            id
+        }
+    }
+}


### PR DESCRIPTION
i did some tests and it seem that the performance is way better this way  (550% speedup)
we're now using `Vec<u32>` as opposed to just passing the `Vec<String>` directly to `Chain<T>`.

this also means that `Chain<T>` can now be used for whatever as long as the `T` implements `Eq + Hash + Clone + std::fmt::Debug`